### PR TITLE
Async after read

### DIFF
--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -21,7 +21,7 @@ function ODataServer(serviceUrl) {
 
     this.cfg = {
         serviceUrl: serviceUrl,
-        afterRead: function() {},
+        afterRead: function(col, res, cb) { cb() },
         beforeQuery: function(col, query, cb) { cb();},
         executeQuery: ODataServer.prototype.executeQuery.bind(this),
         beforeInsert: function(col, query, cb) { cb();},
@@ -156,8 +156,9 @@ ODataServer.prototype.executeQuery = function (col, query, cb) {
             if (err)
                 return cb(err);
 
-            self.cfg.afterRead(col, res);
-            cb(null, res);
+            self.cfg.afterRead(col, res, function (err, res) {
+                cb(null, res);
+            });
         });
     });
 };

--- a/lib/odataServer.js
+++ b/lib/odataServer.js
@@ -21,7 +21,7 @@ function ODataServer(serviceUrl) {
 
     this.cfg = {
         serviceUrl: serviceUrl,
-        afterRead: function(col, res, cb) { cb() },
+        afterRead: function(col, res, cb) { cb(null, res); },
         beforeQuery: function(col, query, cb) { cb();},
         executeQuery: ODataServer.prototype.executeQuery.bind(this),
         beforeInsert: function(col, query, cb) { cb();},
@@ -157,7 +157,7 @@ ODataServer.prototype.executeQuery = function (col, query, cb) {
                 return cb(err);
 
             self.cfg.afterRead(col, res, function (err, res) {
-                cb(null, res);
+                cb(err, res);
             });
         });
     });


### PR DESCRIPTION
@pablods this code makes afterRead() an asynchronous function so that we can hook up, transform the answer (within another async query) so we can chain this stuff
This is related to getting applications who's bot failed to run
